### PR TITLE
updated usages for jssha's newest version

### DIFF
--- a/api/wechat.js
+++ b/api/wechat.js
@@ -243,8 +243,9 @@ var sign = function (jsapi_ticket, url, nonce, timestamp) {
   };
   var string = raw(ret);
   var jsSHA = require('jssha');
-  var shaObj = new jsSHA(string, 'TEXT');
-  ret.signature = shaObj.getHash('SHA-1', 'HEX');
+  var shaObj = new jsSHA('SHA-1', 'TEXT');
+  shaObj.update(string);
+  ret.signature = shaObj.getHash("HEX"); 
 
   return ret;
 };

--- a/package.json
+++ b/package.json
@@ -4,33 +4,26 @@
   "description": "The Nodejs server for manage Wechat access_token, jsapi ticket and get signature",
   "author": "tangramor <tangramor@gmail.com>",
   "private": true,
-  "scripts": {
-    "start": "node app.js"
-  },
+  "scripts": {},
   "dependencies": {
+    "body-parser": "latest",
+    "compression": "latest",
+    "connect-redis": "latest",
+    "cookie-parser": "latest",
+    "errorhandler": "latest",
     "express": "latest",
     "express-session": "latest",
-    "multer": "latest",
-    "body-parser": "latest",
-    "morgan": "latest",
-    "compression": "latest",
     "method-override": "latest",
-    "cookie-parser": "latest",
-    "serve-favicon": "latest",
-    "serve-static": "latest",
-    "errorhandler": "latest",
+    "morgan": "latest",
+    "multer": "latest",
+    "redis": "^0.12.1",
     "request": "latest",
-
-    "redis": "latest",
-    "connect-redis": "latest"
+    "serve-favicon": "latest",
+    "serve-static": "latest"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "main": "index",
-  "scripts": {
-  },
   "engines": {
     "node": ">= 0.6"
   }
 }
-


### PR DESCRIPTION
- 报错如下:

```
/home/hophacker/wx_jsapi_sign/node_modules/redis/index.js:602
                throw err;
                      ^
Error: Cannot find module 'jssha'
```
- 原因: 所有类都是引用的latest, 而lastest的jssha的用法也变了
- 结语: 我们是不是可以一起合作把这个library做得更好, 我觉得这个做得挺好的.
